### PR TITLE
Fixed settings prefetching taking so long

### DIFF
--- a/src/hooks/prefetch/prefetchVersion.ts
+++ b/src/hooks/prefetch/prefetchVersion.ts
@@ -9,10 +9,14 @@ import { VersionService } from 'services';
  */
 export async function prefetchVersion(queryClient: QueryClient) {
   const versionService = VersionService.getInstance();
-  const versionInfo = {
-    version: await versionService.getVersion(),
-    timeOfLastCheck: versionService.getLastCheckedForUpdate()?.toLocaleString(),
-    isCurrentlyUpdating: versionService.getIsCurrentlyUpdating()
-  };
+  const version = versionService.getVersionForPrefetch();
+  let versionInfo = undefined;
+  // Only set the version if we have one cached, otherwise the page takes too long to load.
+  if (version)
+    versionInfo = {
+      version,
+      timeOfLastCheck: versionService.getLastCheckedForUpdate()?.toLocaleString(),
+      isCurrentlyUpdating: versionService.getIsCurrentlyUpdating()
+    };
   queryClient.setQueryData(VERSION_QUERY_KEY, versionInfo);
 }

--- a/src/services/VersionService.ts
+++ b/src/services/VersionService.ts
@@ -38,6 +38,15 @@ export class VersionService {
   }
 
   /**
+   * Gets the version for prefetching. This will not check for an update.
+   * @returns The cached version number (e.g. 1.5.2) or undefined if we should check for an update.
+   */
+  public getVersionForPrefetch() {
+    if (this.shouldCheckForUpdate()) return undefined;
+    return this.version;
+  }
+
+  /**
    * Determines if we should check for an update.
    * @returns Whether or not we should check for an update.
    */


### PR DESCRIPTION
# Description

* Fixed settings prefetching taking so long when there is a need to check for a new version.

> ## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds a new feature)
- [ ] Breaking change (fix or feature which breaks existing functionality)
- [ ] DevOps / Scripts
- [ ] Other (please describe)

> ## Standard Checklist

- [x] Comments/documentation added/updated
- [ ] Unit tests added/updated
- [ ] New components use Chakra's `forwardRef`

> ## Security Checklist

- [x] No secrets used (vendor keys, passwords, etc)
- [x] No hardcoded values used (URLs, hostnames, etc)
