### PR TITLE
Changed version prefetching to still return undefined if version data is old

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garage-door-next",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Joshua Drumm",
     "email": "Schythed@gmail.com"

--- a/src/hooks/prefetch/prefetchVersion.ts
+++ b/src/hooks/prefetch/prefetchVersion.ts
@@ -9,14 +9,17 @@ import { VersionService } from 'services';
  */
 export async function prefetchVersion(queryClient: QueryClient) {
   const versionService = VersionService.getInstance();
-  const version = versionService.getVersionForPrefetch();
   let versionInfo = undefined;
-  // Only set the version if we have one cached, otherwise the page takes too long to load.
-  if (version)
-    versionInfo = {
-      version,
-      timeOfLastCheck: versionService.getLastCheckedForUpdate()?.toLocaleString(),
-      isCurrentlyUpdating: versionService.getIsCurrentlyUpdating()
-    };
+  // Only set the version if we have one cached and it hasn't been too long, otherwise the page takes too long to load.
+  if (!versionService.shouldCheckForUpdate()) {
+    const version = versionService.getVersionForPrefetch();
+    if (version)
+      versionInfo = {
+        version,
+        timeOfLastCheck: versionService.getLastCheckedForUpdate()?.toLocaleString(),
+        isCurrentlyUpdating: versionService.getIsCurrentlyUpdating()
+      };
+  }
+
   queryClient.setQueryData(VERSION_QUERY_KEY, versionInfo);
 }


### PR DESCRIPTION
# Description

> ## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds a new feature)
- [ ] Breaking change (fix or feature which breaks existing functionality)
- [ ] DevOps / Scripts
- [ ] Other (please describe)

> ## Standard Checklist

- [x] Comments/documentation added/updated
- [ ] Unit tests added/updated
- [ ] New components use Chakra's `forwardRef`

> ## Security Checklist

- [x] No secrets used (vendor keys, passwords, etc)
- [x] No hardcoded values used (URLs, hostnames, etc)
